### PR TITLE
Anvari2024explore bandit

### DIFF
--- a/anvari2024explore/.gitignore
+++ b/anvari2024explore/.gitignore
@@ -1,0 +1,2 @@
+*.csv
+plan.md

--- a/anvari2024explore/README.md
+++ b/anvari2024explore/README.md
@@ -1,0 +1,8 @@
+### Reference
+
+Anvari, F., Billinger, S., Analytis, P. P., Franco, V. R., & Marchiori, D. (2024). Testing the convergent validity, domain generality, and temporal stability of selected measures of people’s tendency to explore. Nature Communications, 15(1), 7721.
+
+### Data source
+
+https://osf.io/f62my/
+

--- a/anvari2024explore/armed_bandit/generate_prompts.py
+++ b/anvari2024explore/armed_bandit/generate_prompts.py
@@ -1,0 +1,110 @@
+import pandas as pd
+import jsonlines
+import random
+import os
+
+
+# Randomize the names of choice options
+def randomized_choice_options(num_choices=5):
+        names = ["Alpha", "Bravo", "Charlie", "Delta", "Echo"]
+        random.shuffle(names)
+        return names
+
+# Load armed bandit data
+file1 = "armed_bandit_2023-04-28_out.csv"
+file2 = "armed_bandit_2023-06-02_out.csv"
+
+df1 = pd.read_csv(file1)
+df2 = pd.read_csv(file2)
+
+df_all = pd.concat([df1, df2], ignore_index=True)
+
+# Group the data by participant code and session code
+# (Each group corresponds to one experimental session)
+groups = df_all.groupby(["participant.code", "session.code"])
+
+# Fixed instructions text for the multi-armed bandit task
+instructions = (
+        "MULTI‑ARMED BANDIT TASK\n\n"
+        "Instructions:\n"
+        "In this task, five buttons will be displayed on the screen. On each trial you must select one of these buttons by clicking on it. "
+        "Each button is associated with a different average payout. You will first complete a practice block of 20 trials, followed by 4 incentivized blocks of 40 trials each.\n"
+        "After every click the system takes about one second to process your entry. Within a given block, the average payout for each button remains constant—but between blocks the averages may change.\n\n"
+        "Earnings:\n"
+        "At the end of each block you will receive feedback on how many points you earned. Note that the practice block is not scored; only points from the 4 incentivized blocks determine your bonus payment (1 pence per 100 points earned)."
+)
+
+all_prompts = []
+
+# Process each experimental session
+for (participant_code, session_code), df_session in groups:
+        # Sort trials by block and then by trial number
+        df_session = df_session.sort_values(by=["block", "trial"])
+        
+        # Randomize the button names for this session
+        choice_options = randomized_choice_options(num_choices=5)
+        
+        # Start building the prompt text
+        prompt_text = instructions + "\n"
+        prompt_text += "---\n"
+        
+        # Collect reaction times (if available)
+        rt_list = []
+        
+        # Get the unique block numbers (e.g., 1 = practice, 2+ = incentivized)
+        blocks = sorted(df_session["block"].unique())
+        
+        for block in blocks:
+                # Select data for this block and compute cumulative points
+                df_block = df_session[df_session["block"] == block]
+                cumulative_points = df_block["player.payoff.1"].cumsum().tolist()
+                
+                # Label block: Block 1 is practice; subsequent blocks are incentivized (numbered block-1)
+                if block == 1:
+                        prompt_text += "Practice Block:\n\n"
+                else:
+                        prompt_text += f"Incentivized Block {block - 1}:\n\n"
+                
+                # Iterate over trials in the block
+                for i, (_, row) in enumerate(df_block.iterrows()):
+                        trial_num = int(row["trial"])
+                        points = int(row["player.payoff.1"])
+                        cumulative = int(cumulative_points[i])
+                        # Use the participant's selection (assumed 1-indexed) to index into randomized buttons
+                        selection = int(row["player.selection"])
+                        try:
+                                chosen_button = choice_options[selection - 1]
+                        except IndexError:
+                                chosen_button = f"Option{selection}"
+                        
+                        # Record reaction time if available
+                        if "player.submission_times" in row and pd.notnull(row["player.submission_times"]):
+                                        rt_list.append(row["player.submission_times"])
+                        
+                        trial_line = (f"Trial {trial_num}: Displayed buttons: {choice_options}. "
+                                                    f"You selected <<{chosen_button}>> and received {points} points. "
+                                                    f"Total points: {cumulative}.\n")
+                        prompt_text += trial_line
+                prompt_text += "\n"
+        
+        prompt_text += "---\n"
+        prompt_text += "End of session.\n"
+        
+        # Prompt dict for one session
+        prompt_dict = {
+                "text": prompt_text,
+                "experiment": "multi_armed_bandit",
+                "participant": participant_code,
+                "session": session_code,
+                "RTs": rt_list
+        }
+        
+        all_prompts.append(prompt_dict)
+
+# Write all to jsonl
+script_dir = os.path.dirname(os.path.abspath(__file__))
+output_file = os.path.join(script_dir, "prompts.jsonl")
+with jsonlines.open(output_file, mode='w') as writer:
+        writer.write_all(all_prompts)
+
+print(f"Created {len(all_prompts)} prompt(s) in {output_file}.")

--- a/anvari2024explore/armed_bandit/generate_prompts.py
+++ b/anvari2024explore/armed_bandit/generate_prompts.py
@@ -1,19 +1,18 @@
+import os
+import sys
 import pandas as pd
 import jsonlines
-import random
-import os
 
+project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../"))
+if project_root not in sys.path:
+    sys.path.insert(0, project_root)
+    
+from utils import randomized_choice_options
 
-# Randomize the names of choice options
-def randomized_choice_options(num_choices=5):
-        names = ["Alpha", "Bravo", "Charlie", "Delta", "Echo"]
-        random.shuffle(names)
-        return names
-
-# Load armed bandit data
-file1 = "armed_bandit_2023-04-28_out.csv"
-file2 = "armed_bandit_2023-06-02_out.csv"
-
+# Load data
+script_dir = os.path.dirname(os.path.abspath(__file__))
+file1 = os.path.join(script_dir, "armed_bandit_2023-04-28_out.csv")
+file2 = os.path.join(script_dir, "armed_bandit_2023-06-02_out.csv")
 df1 = pd.read_csv(file1)
 df2 = pd.read_csv(file2)
 
@@ -25,86 +24,93 @@ groups = df_all.groupby(["participant.code", "session.code"])
 
 # Fixed instructions text for the multi-armed bandit task
 instructions = (
-        "MULTI‑ARMED BANDIT TASK\n\n"
-        "Instructions:\n"
-        "In this task, five buttons will be displayed on the screen. On each trial you must select one of these buttons by clicking on it. "
-        "Each button is associated with a different average payout. You will first complete a practice block of 20 trials, followed by 4 incentivized blocks of 40 trials each.\n"
-        "After every click the system takes about one second to process your entry. Within a given block, the average payout for each button remains constant—but between blocks the averages may change.\n\n"
-        "Earnings:\n"
-        "At the end of each block you will receive feedback on how many points you earned. Note that the practice block is not scored; only points from the 4 incentivized blocks determine your bonus payment (1 pence per 100 points earned)."
+    "You will see five buttons on the screen. Each trial, you must choose one button by clicking on it. "
+    "Every button has a different average payout. First, you will complete a 20-trial practice block (not scored). "
+    "Then, you will complete 4 incentivized blocks of 40 trials each.\n\n"
+    "After you click a button, the system takes about one second to process your choice. "
+    "The average payout for each button stays the same within a block, but may change between blocks. "
+    "At the end of each block, you will see how many points you earned in that block. "
+    "Only the points from the 4 incentivized blocks count toward your bonus. The bonus rate is 1 pence per 100 points."
 )
 
 all_prompts = []
 
 # Process each experimental session
 for (participant_code, session_code), df_session in groups:
-        # Sort trials by block and then by trial number
-        df_session = df_session.sort_values(by=["block", "trial"])
-        
-        # Randomize the button names for this session
-        choice_options = randomized_choice_options(num_choices=5)
-        
-        # Start building the prompt text
-        prompt_text = instructions + "\n"
-        prompt_text += "---\n"
-        
-        # Collect reaction times (if available)
-        rt_list = []
-        
-        # Get the unique block numbers (e.g., 1 = practice, 2+ = incentivized)
-        blocks = sorted(df_session["block"].unique())
-        
-        for block in blocks:
-                # Select data for this block and compute cumulative points
-                df_block = df_session[df_session["block"] == block]
-                cumulative_points = df_block["player.payoff.1"].cumsum().tolist()
-                
-                # Label block: Block 1 is practice; subsequent blocks are incentivized (numbered block-1)
-                if block == 1:
-                        prompt_text += "Practice Block:\n\n"
-                else:
-                        prompt_text += f"Incentivized Block {block - 1}:\n\n"
-                
-                # Iterate over trials in the block
-                for i, (_, row) in enumerate(df_block.iterrows()):
-                        trial_num = int(row["trial"])
-                        points = int(row["player.payoff.1"])
-                        cumulative = int(cumulative_points[i])
-                        # Use the participant's selection (assumed 1-indexed) to index into randomized buttons
-                        selection = int(row["player.selection"])
-                        try:
-                                chosen_button = choice_options[selection - 1]
-                        except IndexError:
-                                chosen_button = f"Option{selection}"
-                        
-                        # Record reaction time if available
-                        if "player.submission_times" in row and pd.notnull(row["player.submission_times"]):
-                                        rt_list.append(row["player.submission_times"])
-                        
-                        trial_line = (f"Trial {trial_num}: Displayed buttons: {choice_options}. "
-                                                    f"You selected <<{chosen_button}>> and received {points} points. "
-                                                    f"Total points: {cumulative}.\n")
-                        prompt_text += trial_line
-                prompt_text += "\n"
-        
-        prompt_text += "---\n"
-        prompt_text += "End of session.\n"
-        
-        # Prompt dict for one session
-        prompt_dict = {
-                "text": prompt_text,
-                "experiment": "multi_armed_bandit",
-                "participant": participant_code,
-                "session": session_code,
-                "RTs": rt_list
-        }
-        
-        all_prompts.append(prompt_dict)
+    # Sort trials by block and then by trial number
+    df_session = df_session.sort_values(by=["block", "trial"])
+
+    # Randomize the button names for this session
+    choice_options = randomized_choice_options(num_choices=5)
+
+    # Start building the prompt text
+    prompt_text = instructions + "\n"
+    prompt_text += "\n"
+
+    # Collect reaction times (if available)
+    rt_list = []
+
+    # Get the unique block numbers (e.g., 1 = practice, 2+ = incentivized)
+    blocks = sorted(df_session["block"].unique())
+
+    for block in blocks:
+        # Select data for this block and compute cumulative points
+        df_block = df_session[df_session["block"] == block]
+        cumulative_points = df_block["player.payoff.1"].cumsum().tolist()
+
+        # Label block: Block 1 is practice; subsequent blocks are incentivized (numbered block-1)
+        if block == 1:
+            prompt_text += "Practice Block:\n\n"
+        else:
+            prompt_text += f"Incentivized Block {block - 1}:\n\n"
+
+        # Iterate over trials in block
+        for i, (_, row) in enumerate(df_block.iterrows()):
+            trial_num = int(row["trial"])
+            points = int(row["player.payoff.1"])
+            cumulative = int(cumulative_points[i])
+
+            # Use the participant's selection (assumed 1-indexed) to index into randomized buttons
+            selection = int(row["player.selection"])
+            try:
+                chosen_button = choice_options[selection - 1]
+            except IndexError:
+                chosen_button = f"Option{selection}"
+
+            # Record reaction time if available
+            if "player.submission_times" in row and pd.notnull(row["player.submission_times"]):
+                rt_list.append(row["player.submission_times"])
+
+            displayed_buttons = ", ".join(choice_options)
+
+            # Trial description
+            trial_line = (
+                f"Trial {trial_num}: Displayed buttons: {displayed_buttons}. "
+                f"You selected <<{chosen_button}>> and received {points} points. "
+                f"Total points: {cumulative}.\n"
+            )
+            prompt_text += trial_line
+
+        prompt_text += "\n"
+
+    prompt_text += "\n"
+    prompt_text += "End of session.\n"
+
+    # Prompt dict for one session
+    prompt_dict = {
+        "text": prompt_text,
+        "experiment": "multi_armed_bandit",
+        "participant": participant_code,
+        "session": session_code,
+        "RTs": rt_list
+    }
+
+    all_prompts.append(prompt_dict)
 
 # Write all to jsonl
 script_dir = os.path.dirname(os.path.abspath(__file__))
 output_file = os.path.join(script_dir, "prompts.jsonl")
 with jsonlines.open(output_file, mode='w') as writer:
-        writer.write_all(all_prompts)
+    writer.write_all(all_prompts)
 
 print(f"Created {len(all_prompts)} prompt(s) in {output_file}.")

--- a/anvari2024explore/armed_bandit/prompts.jsonl.zip
+++ b/anvari2024explore/armed_bandit/prompts.jsonl.zip
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:b3296017365c44d388f46bfeed78fb4d12a34495acdc2e77adaccfb358906a8d
-size 2484388
+oid sha256:02a093b13b62647e2aed3f0b3a8e797dbdd48e1a93fb8d322d8f7549e18c1d2f
+size 2460615

--- a/anvari2024explore/armed_bandit/prompts.jsonl.zip
+++ b/anvari2024explore/armed_bandit/prompts.jsonl.zip
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:b3296017365c44d388f46bfeed78fb4d12a34495acdc2e77adaccfb358906a8d
+size 2484388


### PR DESCRIPTION
This PR adds the first paradigm, the multi-armed bandit task from the paper. The new folder is located under:

It includes:
	•	A README.md with details of the experiment.
	•	A generate_prompts.py script that processes the raw data.
	•	A zipped prompts.jsonl file containing participant-level session transcriptions.

Additionally, I’ve reorganized our contribution to fit the proposed structure - grouping all paradigms from the paper under a single top-level directory (explore_exploit_2023_kriegmair) with each paradigm in its own subdirectory. Could you please review whether this slightly adjusted folder structure meets the collaboration guidelines:

```
anvari2024explore/
├── README.md         
├── multi_armed_bandit/
│   ├── README.md
│   ├── generate_prompts.py
│   └── prompts.jsonl.zip
├── alien_game/         
│   ├── README.md
│   ├── generate_prompts.py
│   └── prompts.jsonl.zip
├── optional_stopping/   
│   ├── README.md
│   ├── generate_prompts.py
│   └── prompts.jsonl.zip
...
``` 

Further paradigms (Alien Game, Optional Stopping, Sampling Paradigm, and Observe or Bet) will follow in subsequent PRs.

Thanks for your feedback!